### PR TITLE
Fix typo in hasResponse

### DIFF
--- a/src/ResponseViewElement.js
+++ b/src/ResponseViewElement.js
@@ -183,7 +183,7 @@ export class ResponseViewElement extends LitElement {
     if (!request) {
       return false;
     }
-    const { response } = request;
+    const { response } = this;
     return !!response;
   }
 


### PR DESCRIPTION
Either some logic has changed recently and `request` no longer contains the `response` object (which is likely the case from what I see here https://github.com/advanced-rest-client/api-request/blob/main/src/ApiRequestPanelElement.js#L437 and in the `TransportRequest` type) or the API console recently switched to this component and `ApiResponseViewElement` no longer renders the response data (not showing anything when making a request from the request panel). This PR fixes the issue. 

If `request` should no longer contain the `response` object, the description of the `response` object and unit tests should be updated as well to match current implementation.