### PR TITLE
W-10556766 Array response cannot be focused

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advanced-rest-client/arc-response",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@advanced-rest-client/arc-response",
   "description": "A module containing the UI regions and the logic to render and support HTTP response in Advanced REST Client.",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/lib/PrismFolding.js
+++ b/src/lib/PrismFolding.js
@@ -111,7 +111,7 @@ Prism.hooks.add('brace-complete', (env) => {
   }
   code.classList.add('toggle-padding');
   nodes.forEach((node) => {
-    const target = document.createElement('span');
+    const target = document.createElement('button');
     target.classList.add('toggle-target');
     target.classList.add('opened');
     target.title = 'Toggle visibility';

--- a/src/styles/Highlight.styles.js
+++ b/src/styles/Highlight.styles.js
@@ -61,6 +61,7 @@ pre {
 }
 
 .toggle-target {
+  all: unset;
   position: absolute;
   width: 12px;
   height: 12px;
@@ -71,6 +72,11 @@ pre {
   justify-content: center;
   cursor: pointer;
   margin-top: 0.2rem;
+}
+
+.toggle-target:focus {
+  border: 1px solid rgb(0 95 204);
+  box-shadow: 0px 0px 1px 0px rgb(0 88 200 / 87%);
 }
 
 .toggle-target::before {

--- a/test/ResponseHighlightElement.test.js
+++ b/test/ResponseHighlightElement.test.js
@@ -90,7 +90,7 @@ describe('ResponseHighlightElement', () => {
       await aTimeout(0);
       const compare =
         '<code class="language- toggle-padding" id="output">' + 
-        '<span class="toggle-target opened" title="Toggle visibility" aria-label="Activate to toggle visibility of the lines"></span>' + 
+        '<button class="toggle-target opened" title="Toggle visibility" aria-label="Activate to toggle visibility of the lines"></button>' + 
         '<span class="token punctuation brace-curly brace-open brace-level-1" id="pair-0-close" data-open="pair-0-open">{</span>' + 
         '<span class="token property">"test"</span><span class="token operator">:</span> <span class="token boolean">true</span>' + 
         '<span class="token punctuation brace-curly brace-close brace-level-1" id="pair-0-open" data-close="pair-0-close">}</span>' +
@@ -287,12 +287,36 @@ describe('ResponseHighlightElement', () => {
       await aTimeout(0);
       const compare =
         '<code class="language- toggle-padding" id="output">' + 
-        '<span class="toggle-target opened" title="Toggle visibility" aria-label="Activate to toggle visibility of the lines"></span>' + 
+        '<button class="toggle-target opened" title="Toggle visibility" aria-label="Activate to toggle visibility of the lines"></button>' + 
         '<span class="token punctuation brace-curly brace-open brace-level-1" id="pair-0-close" data-open="pair-0-open">{</span>' + 
         '<span class="token property">"test"</span><span class="token operator">:</span> <span class="token boolean">true</span>' + 
         '<span class="token punctuation brace-curly brace-close brace-level-1" id="pair-0-open" data-close="pair-0-close">}</span>' +
         '</code>';
       assert.dom.equal(element[outputElement], compare, { ignoreAttributes: ['aria-label'] });
+    });
+  });
+
+  describe('test toggle button in code viwer', () => {
+    beforeEach(() => {
+      // @ts-ignore
+      Prism.plugins.matchBraces.resetIndex();
+    });
+
+    it("should remove and add class on toggle button", async () => {
+      const element = await jsonNpFixture();
+      await aTimeout(0);
+      const button = /** @type HTMLElement */ (
+        element[outputElement].querySelector(".toggle-target")
+      );
+
+      // @ts-ignore
+      assert.equal(button.classList, "toggle-target opened");
+      button.click();
+      // @ts-ignore
+      assert.equal(button.classList, "toggle-target");
+      button.click();
+      // @ts-ignore
+      assert.equal(button.classList, "toggle-target opened");
     });
   });
 });

--- a/test/ResponseHighlightElement.test.js
+++ b/test/ResponseHighlightElement.test.js
@@ -296,7 +296,7 @@ describe('ResponseHighlightElement', () => {
     });
   });
 
-  describe('test toggle button in code viwer', () => {
+  describe('test toggle button in code viewer', () => {
     beforeEach(() => {
       // @ts-ignore
       Prism.plugins.matchBraces.resetIndex();


### PR DESCRIPTION
### Description
Add focus event to the button for collapse arrays in the response
  
[Ticket in Jira](https://www.mulesoft.org/jira/browse/APIC-327)
[Ticket in GUS](https://gus.lightning.force.com/a07EE00000lRUxnYAG)

### Technical changes
- Change kind of tag to display to the button 
- Discard default styles of the button tag, with css property `all: unset`
- Add button styles to state focus 
- Fix and add tests

### How test changes
- Clone repo, and go to current branch, run `npm i && npm run start`
- Go to request panel page and try generate a response json 
- In response panel try make focus with tab key, now is posible open and close array, with key`enter` or `space`

### UI screenshots with changes

https://user-images.githubusercontent.com/96145153/154285985-2bb48d31-3a9c-4ec6-88a1-234b2de49462.mov



#### Issue type
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] The created branch follows branching convention: fix/W-x/*, feat/W-x/*, test/W-x/* or chore/W-x/*
- [x] The commit messages have the GUS ticket.
- [x] The PR is rebased with base branch.
- [x] I added tests.
- [x] I validated the fix manually.
- [x] I have performed a self-review of my own code
- [ ] This change requires documentation update
- [x] This change includes library / dependency update.
- [ ] My changes generate no new warnings
